### PR TITLE
App Tracking Transparency Support

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "adjust/ios_sdk" ~> 4.20
-github "mparticle/mparticle-apple-sdk" ~> 8.0
+github "mparticle/mparticle-apple-sdk" ~> 8.2

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This repository contains the [Adjust](https://www.adjust.com) integration for th
 1. Add the kit dependency to your app's Podfile or Cartfile:
 
     ```
-    pod 'mParticle-Adjust', '~> 7.0'
+    pod 'mParticle-Adjust', '~> 8.0'
     ```
 
     OR
 
     ```
-    github "mparticle-integrations/mparticle-apple-integration-adjust" ~> 7.0
+    github "mparticle-integrations/mparticle-apple-integration-adjust" ~> 8.0
     ```
 
 2. Follow the mParticle iOS SDK [quick-start](https://github.com/mParticle/mparticle-apple-sdk), then rebuild and launch your app, and verify that you see `"Included kits: { Adjust }"` in your Xcode console 

--- a/Sources/mParticle-Adjust/MPKitAdjust.m
+++ b/Sources/mParticle-Adjust/MPKitAdjust.m
@@ -136,5 +136,13 @@ NSString *const MPKitAdjustErrorDomain = @"mParticle-Adjust";
     [_kitApi onAttributionCompleteWithResult:attributionResult error:nil];
 }
 
+- (MPKitExecStatus *)setATTStatus:(MPATTAuthorizationStatus)status withATTStatusTimestampMillis:(NSNumber *)attStatusTimestampMillis  API_AVAILABLE(ios(14)){
+    [Adjust requestTrackingAuthorizationWithCompletionHandler:^(NSUInteger status) {
+        NSLog(@"Adjust: App Tracking Transparency Authorization Status set to %lu", (unsigned long)status);
+    }];
+
+    return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceKochava) returnCode:MPKitReturnCodeSuccess];
+}
+
 
 @end

--- a/Sources/mParticle-Adjust/MPKitAdjust.m
+++ b/Sources/mParticle-Adjust/MPKitAdjust.m
@@ -137,11 +137,13 @@ NSString *const MPKitAdjustErrorDomain = @"mParticle-Adjust";
 }
 
 - (MPKitExecStatus *)setATTStatus:(MPATTAuthorizationStatus)status withATTStatusTimestampMillis:(NSNumber *)attStatusTimestampMillis  API_AVAILABLE(ios(14)){
-    [Adjust requestTrackingAuthorizationWithCompletionHandler:^(NSUInteger status) {
-        NSLog(@"Adjust: App Tracking Transparency Authorization Status set to %lu", (unsigned long)status);
-    }];
+    if (status != MPATTAuthorizationStatusNotDetermined) {
+        [Adjust requestTrackingAuthorizationWithCompletionHandler:^(NSUInteger status) {
+            NSLog(@"Adjust: App Tracking Transparency Authorization Status set to %lu", (unsigned long)status);
+        }];
+    }
 
-    return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceKochava) returnCode:MPKitReturnCodeSuccess];
+    return [[MPKitExecStatus alloc] initWithSDKCode:@(MPKitInstanceAdjust) returnCode:MPKitReturnCodeSuccess];
 }
 
 

--- a/mParticle-Adjust.podspec
+++ b/mParticle-Adjust.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
     s.social_media_url = "https://twitter.com/mparticle"
 
     s.ios.deployment_target = "9.0"
-    s.ios.source_files      = 'Sources/**/*.{h,m,mm}'
-    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.0'
+    s.ios.source_files      = 'mParticle-Adjust/*.{h,m,mm}'
+    s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.2'
     s.ios.dependency 'Adjust', '~> 4.20'
 end

--- a/mParticle-Adjust.podspec
+++ b/mParticle-Adjust.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
     s.ios.deployment_target = "9.0"
     s.ios.source_files      = 'mParticle-Adjust/*.{h,m,mm}'
     s.ios.dependency 'mParticle-Apple-SDK/mParticle', '~> 8.2'
-    s.ios.dependency 'Adjust', '~> 4.20'
+    s.ios.dependency 'Adjust', '~> 4.23'
 end


### PR DESCRIPTION
As per Version 4.23 Adjust implemented a wrapper of 'requestTrackingAuthorizationWithCompletionHandler' to allow clients to immediately propagate any authorization status to Adjust. 

https://github.com/adjust/ios_sdk/releases/tag/v4.23.0
https://help.adjust.com/en/article/user-opt-in