### PR TITLE
feat: return MPAdjustKit instead of ADJConfig in instance

### DIFF
--- a/Sources/mParticle-Adjust/MPKitAdjust.m
+++ b/Sources/mParticle-Adjust/MPKitAdjust.m
@@ -101,7 +101,7 @@ NSString *const MPKitAdjustErrorDomain = @"mParticle-Adjust";
 }
 
 - (id const)providerKitInstance {
-    return [self started] ? _adjustConfig : nil;
+    return [self started] ? self : nil;
 }
 
 - (MPKitExecStatus *)setOptOut:(BOOL)optOut {


### PR DESCRIPTION
## Summary
The Playstudios team noticed that using [[MParticle sharedInstance] kitInstance:MPKitInstanceAdjust]; results in returning the ADJConfig and not the MPKitAdjust, which is what's needed to use setDeviceToken. This PR fixes the return value to self (MPKitAdjust) instead of _adjustConfig.

## Testing Plan
N/A
